### PR TITLE
16 remove tiktok iframe

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ export default async function HomePage() {
   return (
     <>
       <HulenPortableText genericSanityPageProps={data.locale} />
+      {/* Commenting out the TikTok iframe, but leacving it available for later.
       <iframe
         title='Frame section containing Hulen TicTok'
         width='325'
@@ -14,7 +15,7 @@ export default async function HomePage() {
         name='__tt_embed__v49072794894336560'
         frameBorder='0'
         src='https://www.tiktok.com/embed/v2/6981771083049340166?lang=en-US&amp;referrer=https%3A%2F%2Fwww.hulen.no%2F'
-      />
+      /> */}
     </>
   )
 }


### PR DESCRIPTION
Please sqush & merge.

Commented out tiktok iframe, in case we want to use it later.
Copied here for convenience(?):

```html
<iframe
        title='Frame section containing Hulen TicTok'
        width='325'
        height='800px'
        name='__tt_embed__v49072794894336560'
        frameBorder='0'
        src='https://www.tiktok.com/embed/v2/6981771083049340166?lang=en-US&amp;referrer=https%3A%2F%2Fwww.hulen.no%2F'
      />

```